### PR TITLE
Add custom-status docs.

### DIFF
--- a/content/admin/custom-status/contents.lr
+++ b/content/admin/custom-status/contents.lr
@@ -1,0 +1,25 @@
+title: Custom Status
+---
+body:
+
+Taiga comes with a number of predefined statuses for User Stories, Tasks and Issues.
+
+Users with administration permissions will be able to create or modify statuses for their project's User Stories, Tasks and Issues
+
+
+### 1. Configure Custom Status
+
+1. Go to one of your Taiga projects.
+2. Click on *admin* button. _In this example we will focus on User Stories, but this feature is also available on tasks and issues and same steps should be followed to edit them._
+3. Go to *Attributes > Status* - scroll to the 'US STATUSES' section.
+4. Either click on the *edit* icon to modify a status, or click *Add new status* to create a new one.
+5. Save the changes.
+
+### 2. Using Custom Status
+
+You can set the status on any of your US/Tasks/Issues as required.
+
+You can change the status of a US/Task/Issue using [commit messages](https://taiga.io/support/changing-elements-status-via-commit-message/).
+
+---
+order: 15

--- a/content/integrations/changing-elements-status-via-commit-message/contents.lr
+++ b/content/integrations/changing-elements-status-via-commit-message/contents.lr
@@ -10,9 +10,10 @@ Just add to your commit message something like:
 TG-REF #STATUS-slug
 ```
 - **REF**: US/Issue/Task reference of the element you want to modify
-- **STATUS**: New status slug to set, you can find all of them in: US STATUSES
+- **STATUS**: New status slug to set.
 
-### An example, please!
+You can [find and modify status values](https://taiga.io/admin/custom-status/) for any project.
+
 
 ```
 TG-123 #closed


### PR DESCRIPTION
Following on from taigaio/taiga-back#633 I've attempted to add a quick page explaining how to find and modify statuses, and link this into the section on changing status via commit messages.

I don't have a place to test this with Lektor currently, so apologies if there are any build errors.

Hopefully this is useful to the project!
