### PR TITLE
link to AD auth plugin

### DIFF
--- a/content/misc/community-contributions/contents.lr
+++ b/content/misc/community-contributions/contents.lr
@@ -159,6 +159,11 @@ Taiga plugin for SAML authentication
 - https://github.com/jgiannuzzi/taiga-contrib-saml-auth
 - Jonathan Giannuzzi [@jgiannuzzi](https://github.com/jgiannuzzi)
 
+### taiga-contrib-ad-auth
+Taiga plugin for Active Directory authentication
+- https://github.com/stemid/taiga-contrib-ad-auth
+- Stefan Midjich [@stemid](https://github.com/stemid)
+
 
 ## Dropbox
 


### PR DESCRIPTION
This plugin is more focused on Active Directory by combining both Kerberos for auth and LDAP for looking up attributes. 